### PR TITLE
Block self-messaging

### DIFF
--- a/Volunteer_Platform_API_Documentation.md
+++ b/Volunteer_Platform_API_Documentation.md
@@ -125,6 +125,18 @@ You used `ApplicationResource`, `OpportunityResource`, etc. to return readable d
 }
 ```
 
+## 📨 Messaging
+
+When sending messages using `/api/{role}/messages/send`, the `receiver_id` must be a different user. If the authenticated user tries to send a message to themselves, the API responds with:
+
+```json
+{
+  "status": false,
+  "message": "Cannot message yourself",
+  "data": null
+}
+```
+
 ---
 
 ## 📦 Postman Setup Notes

--- a/app/Http/Controllers/Admin/MessageController.php
+++ b/app/Http/Controllers/Admin/MessageController.php
@@ -45,9 +45,13 @@ class MessageController extends Controller
     public function send(Request $request)
     {
         $request->validate([
-            'receiver_id'  => 'required|exists:users,id|different:auth_user_id',
+            'receiver_id'  => 'required|exists:users,id',
             'message_text' => 'required|string|max:1000',
         ]);
+
+        if ($request->receiver_id == $request->user()->id) {
+            return $this->error('Cannot message yourself', 422);
+        }
 
         $sender = $request->user();
 

--- a/app/Http/Controllers/Organizer/MessageController.php
+++ b/app/Http/Controllers/Organizer/MessageController.php
@@ -45,9 +45,13 @@ class MessageController extends Controller
     public function send(Request $request)
     {
         $request->validate([
-            'receiver_id'  => 'required|exists:users,id|different:auth_user_id',
+            'receiver_id'  => 'required|exists:users,id',
             'message_text' => 'required|string|max:1000',
         ]);
+
+        if ($request->receiver_id == $request->user()->id) {
+            return $this->error('Cannot message yourself', 422);
+        }
 
         $sender = $request->user();
 

--- a/app/Http/Controllers/Volunteer/MessageController.php
+++ b/app/Http/Controllers/Volunteer/MessageController.php
@@ -47,9 +47,13 @@ class MessageController extends Controller
     public function send(Request $request)
     {
         $request->validate([
-            'receiver_id'  => 'required|exists:users,id|different:auth_user_id',
+            'receiver_id'  => 'required|exists:users,id',
             'message_text' => 'required|string|max:1000',
         ], [], ['receiver_id' => 'recipient']);
+
+        if ($request->receiver_id == $request->user()->id) {
+            return $this->error('Cannot message yourself', 422);
+        }
 
         $sender = $request->user();
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,9 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="APP_KEY" value="base64:gtm8uzXvO2sZ6KnDXhyFSmz/ix4vbFFyPFwetJwO+oQ="/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/MessageSendTest.php
+++ b/tests/Feature/MessageSendTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class MessageSendTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cannot_send_message_to_self(): void
+    {
+        $user = User::factory()->create(['role' => 'volunteer']);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->postJson('/api/volunteer/messages/send', [
+            'receiver_id' => $user->id,
+            'message_text' => 'hello',
+        ]);
+
+        $response->assertStatus(422)
+                 ->assertJson(['message' => 'Cannot message yourself']);
+    }
+}


### PR DESCRIPTION
## Summary
- prevent users from messaging themselves in MessageController
- add tests for self messaging check
- document messaging behavior in API docs
- enable sqlite database for tests

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6885f4cdfddc8320bf2ec0a2c4fbffad