### PR TITLE
Add seeders for categories and 60 opportunities

### DIFF
--- a/database/factories/OpportunityFactory.php
+++ b/database/factories/OpportunityFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Opportunity;
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Opportunity>
+ */
+class OpportunityFactory extends Factory
+{
+    protected $model = Opportunity::class;
+
+    public function definition(): array
+    {
+        return [
+            'organizer_id' => 2,
+            'category_id' => Category::inRandomOrder()->value('id'),
+            'title' => $this->faker->sentence(3),
+            'description' => $this->faker->paragraph(),
+            'location' => $this->faker->city(),
+            'start_date' => $this->faker->dateTimeBetween('+1 days', '+1 month')->format('Y-m-d'),
+            'end_date' => $this->faker->dateTimeBetween('+1 month', '+2 months')->format('Y-m-d'),
+            'status' => 'approved',
+        ];
+    }
+}

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Category;
+use Illuminate\Database\Seeder;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $categories = [
+            'Environment',
+            'Health',
+            'Education',
+            'Community',
+            'Animal Welfare',
+        ];
+
+        foreach ($categories as $name) {
+            Category::create(['name' => $name]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,7 @@ class DatabaseSeeder extends Seeder
     {
 
         $this->call(UserSeeder::class);
+        $this->call(CategorySeeder::class);
         $this->call(OpportunitySeeder::class);
         // \App\Models\User::factory(10)->create();
 

--- a/database/seeders/OpportunitySeeder.php
+++ b/database/seeders/OpportunitySeeder.php
@@ -3,8 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\Opportunity;
-use Carbon\Carbon;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class OpportunitySeeder extends Seeder
@@ -14,16 +12,6 @@ class OpportunitySeeder extends Seeder
      */
     public function run(): void
     {
-        for ($i = 1; $i <= 5; $i++) {
-            Opportunity::create([
-                'title' => "Opportunity #$i",
-                'description' => "Description for opportunity $i",
-                'location' => "City $i",
-                'start_date' => Carbon::now()->addDays($i),
-                'end_date' => Carbon::now()->addDays($i + 5),
-                'organizer_id' => 2,
-                'status' => 'approved',
-            ]);
-        }
+        Opportunity::factory()->count(60)->create();
     }
 }


### PR DESCRIPTION
## Summary
- create `CategorySeeder` with basic names
- refactor `OpportunitySeeder` to generate 60 records using a factory
- add `OpportunityFactory` for randomized data
- update `DatabaseSeeder` to include categories

## Testing
- `php artisan migrate --seed`
- `./vendor/bin/phpunit --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6885f3bb0708832095eb8c98ab51cf73