### PR TITLE
Rewrite API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,66 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Volunteer Platform
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+This repository contains the source code for a simple volunteer management API built with [Laravel](https://laravel.com/).
 
-## About Laravel
+## Getting Started
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+```bash
+# Install PHP dependencies
+composer install
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+# Copy the example environment and generate an app key
+cp .env.example .env
+php artisan key:generate
+```
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+Configure the database credentials and any other options in your `.env` file before continuing.
 
-## Learning Laravel
+### Environment Variables
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+The `.env.example` file contains all of the environment variables used by the application. Common settings include:
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+```
+APP_NAME=Laravel
+APP_ENV=local
+APP_KEY=               # generated via `php artisan key:generate`
+APP_URL=http://localhost
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=laravel
+DB_USERNAME=root
+DB_PASSWORD=
 
-## Laravel Sponsors
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit
+MAIL_PORT=1025
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=null
+MAIL_FROM_ADDRESS="hello@example.com"
+MAIL_FROM_NAME="${APP_NAME}"
+```
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+## Database Migrations & Seeding
 
-### Premium Partners
+Run the migrations and seeders to create example users and opportunities:
 
-- **[Vehikl](https://vehikl.com/)**
-- **[Tighten Co.](https://tighten.co)**
-- **[WebReinvent](https://webreinvent.com/)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel/)**
-- **[Cyber-Duck](https://cyber-duck.co.uk)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Jump24](https://jump24.co.uk)**
-- **[Redberry](https://redberry.international/laravel/)**
-- **[Active Logic](https://activelogic.com)**
-- **[byte5](https://byte5.de)**
-- **[OP.GG](https://op.gg)**
+```bash
+php artisan migrate --seed
+```
 
-## Contributing
+The seeders defined in `database/seeders` will create an administrator, organiser and volunteer account along with some sample opportunities.
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+## Running Tests
 
-## Code of Conduct
+Execute the full test suite with:
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+```bash
+php artisan test
+```
 
-## Security Vulnerabilities
+## API Usage
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+See [`Volunteer_Platform_API_Documentation.md`](Volunteer_Platform_API_Documentation.md) for a list of endpoints and examples. A Postman collection is provided in `Full Volunteer Platform Collection.postman_collection.json` which can be imported for quick testing.
 
-## License
-
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/Volunteer_Platform_API_Documentation.md
+++ b/Volunteer_Platform_API_Documentation.md
@@ -1,134 +1,131 @@
 # Volunteer Platform API Documentation
 
-## ✅ Platform Overview
-This platform connects **Volunteers** with **Organizers** through **Opportunities**. The **Admin** oversees and approves opportunities and reviews applications.
-
-Users have 3 roles:
-- **Admin**
-- **Organizer**
-- **Volunteer**
+This document explains how to interact with the Volunteer Platform API, which is built with Laravel. The API lets **organizers** publish volunteer opportunities and manage applications, while **volunteers** can browse and apply. An **admin** approves opportunities and monitors applications.
 
 ---
 
-## 🔐 Authentication API
-
-| Endpoint         | Method | Description |
-|------------------|--------|-------------|
-| `/api/register`  | POST   | Register a new user (provide `name`, `email`, `password`, `role`) |
-| `/api/login`     | POST   | Login with email and password |
-| `/api/logout`    | POST   | Logout the user |
-| `/api/me`        | GET    | Get current authenticated user info |
+## Table of Contents
+1. [Getting Started](#getting-started)
+2. [Authentication](#authentication)
+3. [Role Capabilities](#role-capabilities)
+4. [Request & Response Format](#request--response-format)
+5. [Postman Collection](#postman-collection)
 
 ---
 
-## 👥 Roles Breakdown
+## Getting Started
 
-### 🎯 ORGANIZER
-
-Organizers can:
-- Manage their own **opportunities**
-- View and respond to **applications** on those opportunities
-
-#### 📌 Opportunities (Organizer)
-
-| Endpoint | Method | Description |
-|---------|--------|-------------|
-| `/api/organizer/opportunities` | GET | List all opportunities by this organizer |
-| `/api/organizer/opportunities` | POST | Create a new opportunity |
-| `/api/organizer/opportunities/{id}` | GET | Show details of a specific opportunity |
-| `/api/organizer/opportunities/{id}` | PUT | Update opportunity (title, description, location, dates, etc.) |
-
-#### 📥 Applications (Organizer)
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/organizer/applications/opportunity/{opportunity_id}` | GET | View all applications for your opportunity |
-| `/api/organizer/applications/{application_id}/status` | PUT | Update application status (pending, accepted, rejected) |
+Follow the setup steps in the [README](README.md) to install dependencies, configure your `.env` file, and run migrations/seeders. Once the application is running you can authenticate and begin making API requests.
 
 ---
 
-### 🙋‍♂️ VOLUNTEER
+## Authentication
 
-Volunteers can:
-- Explore opportunities
-- Apply to them
-- View their application history
-
-#### 📌 Opportunities (Volunteer)
+The API uses token-based authentication provided by [Laravel Sanctum](https://laravel.com/docs/sanctum). Obtain a token by registering or logging in:
 
 | Endpoint | Method | Description |
-|---------|--------|-------------|
-| `/api/volunteer/opportunities` | GET | List all approved opportunities (supports filters) |
-| `/api/volunteer/opportunities/{id}` | GET | View specific opportunity details |
+| --- | --- | --- |
+| `/api/register` | `POST` | Register a new user (`name`, `email`, `password`, `role`). |
+| `/api/login` | `POST` | Return an access token for valid credentials. |
+| `/api/logout` | `POST` | Revoke the current token. |
+| `/api/me` | `GET` | Retrieve the authenticated user's details. |
 
-**Filters supported** on `GET /api/volunteer/opportunities`:
-- `category_id`
-- `location`
-- `start_date`
-- `end_date`
-- `title`
+Include the token in an `Authorization` header for subsequent requests:
 
-Example:
 ```
-GET /api/volunteer/opportunities?title=cleanup&location=Damascus&category_id=3
+Authorization: Bearer {token}
 ```
 
-#### 📥 Applications (Volunteer)
+---
 
+## Role Capabilities
+
+### Organizer
+Organizers manage their own opportunities and review volunteer applications.
+
+#### Opportunities
 | Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/volunteer/applications` | POST | Apply to an opportunity (only once per opportunity) |
-| `/api/volunteer/applications/mine` | GET | View all your submitted applications |
+| --- | --- | --- |
+| `/api/organizer/opportunities` | `GET` | List all of the organizer's opportunities. |
+| `/api/organizer/opportunities` | `POST` | Create a new opportunity. |
+| `/api/organizer/opportunities/{id}` | `GET` | Show a single opportunity. |
+| `/api/organizer/opportunities/{id}` | `PUT` | Update an opportunity. |
+
+#### Applications
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/api/organizer/applications/opportunity/{opportunity_id}` | `GET` | List applications for a given opportunity. |
+| `/api/organizer/applications/{application_id}/status` | `PUT` | Change an application's status (`pending`, `accepted`, `rejected`). |
+
+### Volunteer
+Volunteers search for opportunities and submit applications.
+
+#### Opportunities
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/api/volunteer/opportunities` | `GET` | Browse all approved opportunities. Supports filters: `category_id`, `location`, `start_date`, `end_date`, `title`. |
+| `/api/volunteer/opportunities/{id}` | `GET` | View details of an opportunity. |
+
+Example with filters:
+
+```
+GET /api/volunteer/opportunities?title=cleanup&location=Damascus
+```
+
+#### Applications
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/api/volunteer/applications` | `POST` | Apply to an opportunity (only once per opportunity). |
+| `/api/volunteer/applications/mine` | `GET` | View all applications submitted by the volunteer. |
+
+### Admin
+Admins approve opportunities and oversee all activity.
+
+#### Opportunities
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/api/admin/opportunities` | `GET` | List every opportunity with organizer and category info. |
+| `/api/admin/opportunities/{id}/status` | `PUT` | Change opportunity status to `approved` or `rejected`. |
+
+#### Applications
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/api/admin/applications` | `GET` | List every application in the system. |
+| `/api/admin/applications/{id}` | `GET` | Show a specific application. |
 
 ---
 
-### 🛡️ ADMIN
+## Request & Response Format
 
-Admin can:
-- Approve or reject opportunities
-- View all applications
+Requests should be encoded as JSON and include the `Accept: application/json` header. Successful responses share a common structure:
 
-#### 📌 Opportunities (Admin)
-
-| Endpoint | Method | Description |
-|---------|--------|-------------|
-| `/api/admin/opportunities` | GET | List all opportunities with organizer and category |
-| `/api/admin/opportunities/{id}/status` | PUT | Change status to `approved` or `rejected` |
-
-#### 📥 Applications (Admin)
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/admin/applications` | GET | List all submitted applications |
-| `/api/admin/applications/{id}` | GET | Show details of a specific application |
-
----
-
-## 🔄 Request/Response Notes
-
-All responses are wrapped consistently using `ResponseTrait`:
 ```json
 {
   "status": true,
-  "message": "Success message here",
-  "data": { ... }
+  "message": "Success message",
+  "data": {
+    /* payload */
+  }
 }
 ```
 
-You used `ApplicationResource`, `OpportunityResource`, etc. to return readable data like:
-```json
-"opportunity": {
-  "title": "Beach Cleanup",
-  "category": "Environment",
-  "organizer": "CleanEarth Org",
-  "location": "Damascus"
-}
-```
+Resources such as opportunities and applications are returned using Laravel API resources for consistent field names.
 
 ---
 
-## 📦 Postman Setup Notes
+## Postman Collection
 
-- Set global variables in Postman:
-  - `{{base_url}}` for your API base
-  - `{{token}}` will be auto-saved after login
+A ready-to-use Postman collection is available in the repository:
+
+- **File:** `Full Volunteer Platform Collection.postman_collection.json`
+
+Import this collection into Postman and set two global variables:
+
+- `{{base_url}}` – the root URL of your running API (e.g. `http://localhost:8000`)
+- `{{token}}` – automatically populated after you log in via the collection
+
+The collection demonstrates example requests for every endpoint discussed above.
+
+---
+
+Happy volunteering!


### PR DESCRIPTION
## Summary
- completely rewrite `Volunteer_Platform_API_Documentation.md`
- document authentication, role-based endpoints and request format
- reference the Postman collection

## Testing
- `composer install --no-interaction --no-progress --prefer-dist`
- `php artisan key:generate --force`
- `./vendor/bin/phpunit --display-warnings`


------
https://chatgpt.com/codex/tasks/task_e_6885f4ed30e883209aa3522026dc2ece